### PR TITLE
Multer 多圖上傳功能

### DIFF
--- a/controller/userController.js
+++ b/controller/userController.js
@@ -593,8 +593,24 @@ const userController = {
         // 修改背景圖
         const rawFiles = JSON.stringify(req.files)
         const files = JSON.parse(rawFiles)
-        const imgurCover = await imgur.uploadFile(files.cover[0].path)
-        const imgurAvatar = await imgur.uploadFile(files.avatar[0].path)
+        let imgurCover
+        let imgurAvatar
+
+        if (Object.keys(files).length === 0) {
+          imgurCover = 0
+          imgurAvatar = 0
+        } else if (typeof files.cover === 'undefined' && typeof files.avatar !== 'undefined') {
+          // 如果只有更新 avatar
+          imgurCover = 0
+          imgurAvatar = await imgur.uploadFile(files.avatar[0].path)
+        } else if (typeof files.cover !== 'undefined' && typeof files.avatar === 'undefined') {
+          // 如果只有更新 cover
+          imgurAvatar = 0
+          imgurCover = await imgur.uploadFile(files.cover[0].path)
+        } else { // 如果都有更新
+          imgurCover = await imgur.uploadFile(files.cover[0].path)
+          imgurAvatar = await imgur.uploadFile(files.avatar[0].path)
+        }
 
         await User.update(
           {

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -1,7 +1,10 @@
 const bcrypt = require('bcryptjs')
 const { Tweet, User, Like, Reply, Followship } = require('../models')
 const helpers = require('../_helpers')
-const { imgurFileHandler } = require('../helpers/file-helpers')
+
+const imgur = require('imgur')
+const IMGUR_CLIENT_ID = process.env.IMGUR_CLIENT_ID
+imgur.setClientId(IMGUR_CLIENT_ID)
 
 const userController = {
   signUpPage: async (req, res) => {
@@ -522,6 +525,7 @@ const userController = {
   editUser: async (req, res, next) => {
     try {
       const errors = []
+      const loginUserId = helpers.getUser(req) && helpers.getUser(req).id
 
       if (req._parsedUrl.pathname.includes('setting')) {
         const { account, name, email, password, checkPassword } = req.body
@@ -567,40 +571,44 @@ const userController = {
           password: hash
         }, {
           where: {
-            id: helpers.getUser(req).id
+            id: loginUserId
           }
         })
         req.flash('success_messages', '更改成功！')
         return res.redirect('/')
       } else if (req._parsedUrl.pathname.includes('edit')) {
-        // TODO:收背景圖和頭像功能
+        // 修改名字 和 自我介紹內容
         const { name, introduction } = req.body
 
         if (!name) {
           req.flash('error_messages', '名字需要填入！')
-          return res.redirect(`/users/${res.locals.logInUser.id}`)
+          return res.redirect(`/users/${loginUserId}`)
         }
 
         if (introduction.length >= 160) {
           req.flash('error_messages', '自介不能超過 160 字！')
-          return res.redirect(`/users/${res.locals.logInUser.id}`)
+          return res.redirect(`/users/${loginUserId}`)
         }
 
         // 修改背景圖
-        const { file } = req
-        const filePath = await imgurFileHandler(file)
+        const rawFiles = JSON.stringify(req.files)
+        const files = JSON.parse(rawFiles)
+        const imgurCover = await imgur.uploadFile(files.cover[0].path)
+        const imgurAvatar = await imgur.uploadFile(files.avatar[0].path)
+
         await User.update(
           {
             name,
             introduction,
-            cover: filePath || User.cover
+            cover: imgurCover?.link || User.cover,
+            avatar: imgurAvatar?.link || User.avatar
           }, {
             where: {
-              id: helpers.getUser(req).id
+              id: loginUserId
             }
           })
         req.flash('sucesss_messages', '更改成功！')
-        return res.redirect(`/users/${helpers.getUser(req).id}`)
+        return res.redirect(`/users/${loginUserId}`)
       } else {
         console.log('you want to do something fishy?')
         return res.redirect('/')

--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -1,14 +1,17 @@
 const multer = require('multer')
-const upload = multer({ dest: 'temp/' })
-// limit: {
-// // 限制上傳檔案的大小為 1MB
-//   fileSize: 1000000
-// },
-// fileFilter (req, file, cb) {
-//   // 只接受三種圖片格式 jpg jpeg png
-//   if (!file.originalname.match(/\.(jpg|jpeg|png)$/)) {
-//     cb(new Error('Please upload an image'))
-//   }
-//   cb(null, true)
-// }
+const upload = multer({
+  dest: 'temp/',
+  limit: {
+  // 限制上傳檔案的大小為 1MB
+    fileSize: 1000000
+  },
+  fileFilter (req, file, cb) {
+    // 只接受圖片格式 jpg jpeg png gif
+    if (!file.originalname.match(/\.(jpg|jpeg|png|gif)$/)) {
+      cb(new Error('Please upload an image'))
+    }
+    cb(null, true)
+  }
+})
+
 module.exports = upload

--- a/routes/index.js
+++ b/routes/index.js
@@ -51,7 +51,7 @@ router.put('/users/:id/setting', authenticated, userController.editUser)
 
 // 編輯 user 資料
 router.get('/users/:id/edit', authenticated, userController.editUserFakePage)
-router.put('/users/:id/edit', authenticated, upload.single('cover'), userController.editUser)
+router.post('/users/:id/edit', authenticated, upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'cover', maxCount: 1 }]), userController.editUser)
 
 // 查看 user 相關頁面
 router.get('/users/:id/followings', authenticated, userController.getFollowings)

--- a/views/partials/user-profile.hbs
+++ b/views/partials/user-profile.hbs
@@ -35,7 +35,7 @@
                 <label class="form-label" for="cover">背景</label>
                 <input class="form-control-file" type="file" id="cover" name="cover">
               </div>
-              {{!-- TODO:是否要做上傳的圖片預覽? --}}
+              {{!-- TODO:要做上傳的圖片預覽? --}}
 
               {{!-- 原始 avatar 頭像 --}}
               <img src=" {{ user.avatar }}" alt="user-picture" class="rounded-circle" style="width: 64px; height:64px;">

--- a/views/partials/user-profile.hbs
+++ b/views/partials/user-profile.hbs
@@ -19,31 +19,34 @@
     <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
       <div class="modal-dialog">
         <div class="modal-content">
-          {{!-- <div class="modal-header">
-            <h5 class="modal-title" id="staticBackdropLabel">編輯個人資料</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-          </div> --}}
           <div class="modal-body">
-          <form action="/users/{{ user.id }}/edit?_method=PUT" method="post" enctype="multipart/form-data">
+
+          {{!-- 提交表單 --}}
+          <form action="/users/{{ user.id }}/edit" method="POST" enctype="multipart/form-data">
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             <span>編輯個人資料</span>  
             <button class="btn btn-block mt-4" style="border-radius: 50px; background-color:#FF6600; color: white; width:100px; height: 46px;padding: 8px 24px;" type="submit">儲存</button>
             <div class="form-group">
+              {{!-- 原始 cover 背景 --}}
               <img src=" {{ user.cover }}" alt="">
 
-              {{!-- cover 背景 --}}
+              {{!-- cover 背景上傳 --}}
               <div class="form-row mb-3">
                 <label class="form-label" for="cover">背景</label>
                 <input class="form-control-file" type="file" id="cover" name="cover">
               </div>
+              {{!-- TODO:是否要做上傳的圖片預覽? --}}
 
+              {{!-- 原始 avatar 頭像 --}}
               <img src=" {{ user.avatar }}" alt="user-picture" class="rounded-circle" style="width: 64px; height:64px;">
+
               {{!-- avatar 頭像 --}}
               <div class="form-row mb-3">
                 <label class="form-label" for="avatar">頭像</label>
                 <input class="form-control-file" type="file" id="avatar" name="avatar">
               </div>
             </div>
+            {{!-- TODO:是否要做上傳的圖片預覽? --}}
 
             <div class="form-row mb-3">
               <label class="form-label" for="name">名稱</label>


### PR DESCRIPTION
### 是否有跑過本地測試？
- X npm run test 路由沒有動，只加功能所以依舊是 -3
- V 手動測試

### 請寫下手動測試方式與預期行為
編輯個人資料可以同時上傳封面跟大頭照，也可以只更新其中一個

### 是否有使用到新的套件？如果有，請確定以下事項
-nop

### 是否有更新到目錄架構或者更動其他檔案？如果有請說明
nop
### 是否有對基礎架構做重大改變(ex. 更動資料庫，拆 controller)，如果有請說明如何同步變動。
nop
### 其他沒有寫在上面，覺得應該寫在 Pull request 給覆核人看的事項
目前上傳設定只接受圖片格式 jpg jpeg png gif 並且 限制上傳檔案的大小為 1MB
目前把file-heiper的 imgurFileHandler 整個搬進editUser裡了，之後應該要拉出去，所以還是留著file-heiper的 imgurFileHandler 