### PR TITLE
fix reply link & modify reply UX & order by createdAt

### DIFF
--- a/controller/tweetsController.js
+++ b/controller/tweetsController.js
@@ -72,6 +72,7 @@ const tweetsController = {
       result.isLiked = tweet.LikedBy.some(item => item.id === loginUserId)
       const replies = await Reply.findAll({
         where: { tweetId },
+        order: [['createdAt', 'DESC']],
         include: {
           model: User,
           attributes: ['name', 'account', 'avatar']
@@ -125,29 +126,6 @@ const tweetsController = {
       next(err)
     }
   },
-  createFakePage: (req, res, next) => {
-    try {
-      return res.render('createFake')
-    } catch (err) {
-      next(err)
-    }
-  },
-  replyFakePage: async (req, res, next) => {
-    const tweetId = Number(req.params.tweetId)
-    const tweet = await Tweet.findByPk(tweetId, {
-      include: {
-        model: User,
-        attributes: ['name', 'account', 'avatar']
-      },
-      raw: true,
-      nest: true
-    })
-    try {
-      return res.render('replyFake', tweet)
-    } catch (err) {
-      next(err)
-    }
-  },
   addReply: async (req, res, next) => {
     const TweetId = Number(req.params.tweetId)
     const UserId = helpers.getUser(req) && helpers.getUser(req).id
@@ -163,7 +141,7 @@ const tweetsController = {
         TweetId,
         comment
       })
-      return res.redirect('/tweets')
+      return res.redirect('back')
     } catch (err) {
       next(err)
     }

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -241,7 +241,7 @@ const userController = {
             include: [
               {
                 model: Tweet,
-                attributes: ['description'],
+                attributes: ['id', 'description'],
                 include: [
                   {
                     model: User,
@@ -253,7 +253,7 @@ const userController = {
           },
           {
             model: Tweet,
-            attributes: ['description', 'createdAt'],
+            attributes: ['id', 'description', 'createdAt'],
             order: ['createdAt', 'ASC']
           },
           { model: User, as: 'Followings', attributes: ['id'] },

--- a/views/replies.hbs
+++ b/views/replies.hbs
@@ -40,7 +40,7 @@
                 </a>
               </div>
               <div class="profiletweet_description">
-                <a href="/tweets/{{../user.id}}/replies" style="text-decoration: none; color: #171725;">
+                <a href="/tweets/{{this.Tweet.id}}/replies" style="text-decoration: none; color: #171725;">
                   <p style="maxlength=" 140"; ">
                     {{ this.comment }}
                   </p>

--- a/views/tweet.hbs
+++ b/views/tweet.hbs
@@ -123,7 +123,7 @@
                           </a>
                         </div>
                         <div class="media-body" style="margin-left: 30px;">
-                          <form action="/tweets/{{this.id}}/replies" id="tweets" method="post">
+                          <form action="/tweets/{{tweet.id}}/replies" id="tweets" method="post">
                             <div class="d-flex d-inline">
                               <textarea name="comment" id="tweet-content" rows="5" class="form-control"
                                 placeholder="推你的回覆" maxlength="140"


### PR DESCRIPTION
### 是否有跑過本地測試？
- V npm run test  74 passing
- V  手動測試

### 請寫下手動測試方式與預期行為
單一貼文回覆頁修回覆按鈕，發現目前流程是回覆後跳到其他頁就順手改了UX，現在在單一推文下回覆，會回到原本的頁面，並且回覆的順序由新到舊排列
調整使用者頁面下方tab推文與回覆的列表中，點擊回覆的文字會跳到其他不相干tweet的bug，現在點擊使用者的回覆文字，會進入使用者回文的推文單一回覆頁，並在下面可以看到剛剛點的回文
### 是否有使用到新的套件？如果有，請確定以下事項
X
### 是否有更新到目錄架構或者更動其他檔案？如果有請說明
X
### 是否有對基礎架構做重大改變(ex. 更動資料庫，拆 controller)，如果有請說明如何同步變動。
發現還有fake!!!! 刪掉!!!!
### 其他沒有寫在上面，覺得應該寫在 Pull request 給覆核人看的事項
X